### PR TITLE
Fix videos playing when switching between paused tabs

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -13,6 +13,8 @@
 		this.count = 0
 		/** @type {Number}	Needed because there can be two 'video' elements on the page  */
 		this.playerCount = 0
+		/** @type {Boolean} Whether the video has started playing already  */
+		this.alreadyStarted = false
 
 		this.init()
 		this.bind()
@@ -53,7 +55,7 @@
 	// flash: pauseVideo(), playVideo(), getCurrentTime()
 	StopAutoplay.prototype._exec = function (which) {
 		var action = this.flash ? which + 'Video' : which
-		if (this.player[action] !== undefined)
+		if (this.player !== undefined && this.player[action] !== undefined)
 			this.player[action]()
 	}
 
@@ -62,18 +64,19 @@
 	}
 
 	StopAutoplay.prototype.play = function () {
+		this.alreadyStarted = true
 		this._exec('play')
 	}
 
-	StopAutoplay.prototype.handleVisibilityChange = function () {
+	StopAutoplay.prototype.handleVisibilityChange = function (e) {
 		window.setTimeout(function () {
-			if (!document.hidden)
+			if (!document.hidden && !this.alreadyStarted)
 				this.play()
 		}.bind(this), 60)
 	}
 
 	StopAutoplay.prototype.bind = function () {
-		window.addEventListener('focus', this.handleVisibilityChange.bind(this), false) // extended version: automatic playback
+		document.addEventListener('visibilitychange', this.handleVisibilityChange.bind(this), false) // extended version: automatic playback
 
 		window.addEventListener('spfdone', function (e) {
 			console.log('spfdone', e.detail.url)

--- a/src/inject.js
+++ b/src/inject.js
@@ -76,7 +76,7 @@
 	}
 
 	StopAutoplay.prototype.bind = function () {
-		document.addEventListener('visibilitychange', this.handleVisibilityChange.bind(this), false) // extended version: automatic playback
+		window.addEventListener('focus', this.handleVisibilityChange.bind(this), false) // extended version: automatic playback
 
 		window.addEventListener('spfdone', function (e) {
 			console.log('spfdone', e.detail.url)


### PR DESCRIPTION
Whenever I would pause a video and switch to another tab, switching back would start autoplaying the video again. This PR makes it so a video will only start autoplaying once.