### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -33,8 +33,8 @@
 </head>
 <body>
 	Automatically start the video when switching to the tab:&nbsp;&nbsp;
-	<label><input type="radio" name="extended[]" checked>&nbsp;Yes</label>&nbsp;&nbsp;
-	<input type="radio" name="extended[]" id="trigger">
+	<label><input type="radio" name="extended[]" checked/>&nbsp;Yes</label>&nbsp;&nbsp;
+	<input type="radio" name="extended[]" id="trigger"/>
 	<label for="trigger">No</label>
 	<div id="warning">
 		<p>To keep the extension fast, there is no way to change this behaviour through options.</p>
@@ -44,7 +44,7 @@
 	<p>If this extension is helpful for you, I would very much appreciate a
 		<span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span>
 		rating in the <a href="https://chrome.google.com/webstore/detail/stop-autoplay-for-youtube/nilnpbhnhmmjioijfgilcohbknkgfmpa" target="_blank" rel="noopener">Webstore</a>.
-		<br><small>I started developing this extension when I was 14 and I try everything to keep it updated, <i>5 years later</i>.</small>
+		<br/><small>I started developing this extension when I was 14 and I try everything to keep it updated, <i>5 years later</i>.</small>
 	</p>
 </body>
 </html>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and the only changes that have been made is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
